### PR TITLE
Fix a possible NullPointerException while visiting files.

### DIFF
--- a/src/main/java/org/lukhnos/nnio/file/Files.java
+++ b/src/main/java/org/lukhnos/nnio/file/Files.java
@@ -338,13 +338,13 @@ public class Files {
 
   public static Path walkFileTree(Path start, FileVisitor<? super Path> visitor) throws IOException {
     File file = start.toFile();
-    if(!file.canRead()){
+    if (!file.canRead()) {
       return start;
     }
     if (Files.isDirectory(start)) {
       visitor.preVisitDirectory(start, null);
       File[] children = start.toFile().listFiles();
-      if(children != null){
+      if (children != null) {
         for (File child : children) {
           walkFileTree(FileBasedPathImpl.get(child), visitor);
         }

--- a/src/main/java/org/lukhnos/nnio/file/Files.java
+++ b/src/main/java/org/lukhnos/nnio/file/Files.java
@@ -337,14 +337,21 @@ public class Files {
   }
 
   public static Path walkFileTree(Path start, FileVisitor<? super Path> visitor) throws IOException {
+    File file = start.toFile();
+    if(!file.canRead()){
+      return start;
+    }
     if (Files.isDirectory(start)) {
       visitor.preVisitDirectory(start, null);
-      for (File child : start.toFile().listFiles()) {
-        walkFileTree(FileBasedPathImpl.get(child), visitor);
+      File[] children = start.toFile().listFiles();
+      if(children != null){
+        for (File child : children) {
+          walkFileTree(FileBasedPathImpl.get(child), visitor);
+        }
+        visitor.postVisitDirectory(start, null);
       }
-      visitor.postVisitDirectory(start, null);
     } else {
-      visitor.visitFile(start, new BasicFileAttributes(start.toFile()));
+      visitor.visitFile(start, new BasicFileAttributes(file));
     }
     return start;
   }

--- a/src/main/java/org/lukhnos/nnio/file/Files.java
+++ b/src/main/java/org/lukhnos/nnio/file/Files.java
@@ -339,6 +339,7 @@ public class Files {
   public static Path walkFileTree(Path start, FileVisitor<? super Path> visitor) throws IOException {
     File file = start.toFile();
     if (!file.canRead()) {
+      visitor.visitFileFailed(start, new AccessDeniedException(file.toString()));
       return start;
     }
     if (Files.isDirectory(start)) {


### PR DESCRIPTION
Hi there, 
I hope you are still there, since this is the first update after 8 years.
Let me first explain what brought me here.
The Nextcloud android app uses your library for creating the file tree for automatic file uploads. That wouldn't be a problem, if android didn't introduce some weird permissions on android/data/ where some folders/files are completely unreadable.
This causes the line: 
> for (File child : start.toFile().listFiles())

to evaluate to a null value, crashing the entire scanning process.
To fix this bug, I have added 2 checks: One checks if file/directory is readable, the second one fails if the children are a null value.
listFiles() has a weird implementation where it can return a null value: [JavaDoc](https://docs.oracle.com/javase/8/docs/api/java/io/File.html#listFiles--)

I would ask you to upload a new version to maven central, so it can be updated in the Nextcloud android app project.
Also I am fixing this upstream, because my pull request kept getting ignored, so hopefully I have more sucess here. :)


