### PR TITLE
Add FileVisitResult enum as per spec and add correct preVisitDirectory checks

### DIFF
--- a/src/main/java/org/lukhnos/nnio/file/FileVisitResult.java
+++ b/src/main/java/org/lukhnos/nnio/file/FileVisitResult.java
@@ -20,5 +20,8 @@ package org.lukhnos.nnio.file;
  * Substitute for {@link java.nio.file.FileVisitResult}.
  */
 public enum FileVisitResult {
-  CONTINUE
+  CONTINUE,
+  SKIP_SIBLINGS,
+  SKIP_SUBTREE,
+  TERMINATE,
 }

--- a/src/main/java/org/lukhnos/nnio/file/FileVisitResult.java
+++ b/src/main/java/org/lukhnos/nnio/file/FileVisitResult.java
@@ -21,7 +21,5 @@ package org.lukhnos.nnio.file;
  */
 public enum FileVisitResult {
   CONTINUE,
-  SKIP_SIBLINGS,
   SKIP_SUBTREE,
-  TERMINATE,
 }

--- a/src/main/java/org/lukhnos/nnio/file/Files.java
+++ b/src/main/java/org/lukhnos/nnio/file/Files.java
@@ -341,13 +341,15 @@ public class Files {
       return start;
     }
     if (Files.isDirectory(start)) {
-      visitor.preVisitDirectory(start, null);
-      File[] children = start.toFile().listFiles();
-      if (children != null) {
-        for (File child : children) {
-          walkFileTree(FileBasedPathImpl.get(child), visitor);
+      FileVisitResult preVisitDirectoryResult = visitor.preVisitDirectory(start, null);
+      if (preVisitDirectoryResult == FileVisitResult.CONTINUE) {
+        File[] children = start.toFile().listFiles();
+        if (children != null) {
+          for (File child : children) {
+            walkFileTree(FileBasedPathImpl.get(child), visitor);
+          }
+          visitor.postVisitDirectory(start, null);
         }
-        visitor.postVisitDirectory(start, null);
       }
     } else {
       visitor.visitFile(start, new BasicFileAttributes(file));

--- a/src/main/java/org/lukhnos/nnio/file/Files.java
+++ b/src/main/java/org/lukhnos/nnio/file/Files.java
@@ -342,6 +342,7 @@ public class Files {
     }
     if (Files.isDirectory(start)) {
       FileVisitResult preVisitDirectoryResult = visitor.preVisitDirectory(start, null);
+      //currently only CONTINUE and SKIP_SUBTREE is implemented, SKIP_SUBTREE is implicitly implemented here
       if (preVisitDirectoryResult == FileVisitResult.CONTINUE) {
         File[] children = start.toFile().listFiles();
         if (children != null) {


### PR DESCRIPTION
Hi there,
this is another fix needed for nextcloud, since the visitor does indeed use the FileVisitResult.CONTINUE for skipping directories,
which I didn't know until now. The code just checks that the preVisitDirectory returns a CONTINUE, all other options should not visit the directory. This is still needed for nextcloud, so thanks for helping out.

I would need the another maven central version please :)